### PR TITLE
Fix calculation of winner based on totalPoints

### DIFF
--- a/components/game/GameBoard.tsx
+++ b/components/game/GameBoard.tsx
@@ -105,25 +105,20 @@ const GameBoard = () => {
 
   const submit = () => {
     setisLetterPlaced(false)
-    if (tempBoard.length === boardSize ** 2 && gameContext) {
-      affectedRow &&
-        affectedColumn &&
-        submitMove({
-          gameID: gameContext.gameID,
-          userID: gameContext.userUID,
-          board: tempBoard,
-          row: affectedRow,
-          column: affectedColumn,
-          userPoints: gameContext.userPoints,
-        })
+
+    submitMove({
+      gameID: gameContext!.gameID,
+      userID: gameContext!.userUID,
+      board: tempBoard,
+      row: affectedRow!,
+      column: affectedColumn!,
+      userPoints: gameContext!.userPoints,
+    }).then((res) => {
       setBoard(tempBoard)
       setTempBoard([''])
 
-      updateGameState(gameContext)
-    } else {
-      // TODO: add as feeback messeage
-      console.log('You have to place the letter')
-    }
+      updateGameState(gameContext!)
+    })
   }
 
   // Re-render board after response from /api/check

--- a/components/game/utils/submitMove.ts
+++ b/components/game/utils/submitMove.ts
@@ -26,7 +26,7 @@ const submitMove = async ({
     userPoints: userPoints,
   }
 
-  await validateBoard(boardData)
+  return await validateBoard(boardData)
 }
 
 export default submitMove


### PR DESCRIPTION
Close #293 

Await response by `submitMove()` which updates points, then call `updateGameState()` which sets gameState to "END". This leads to totalPoints being updated when calculating winner and updating XP in cloud function

- Return response from submitMove()
- Use promise chain on submitMove()
